### PR TITLE
fix(serverless): restricted golang runtime and automated testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-      working-directory: ./serverless/digitalocean/packages/zest/refresh
+        working-directory: ./serverless/digitalocean/packages/zest/refresh
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: 'go.mod'
       - name: Run Tests
         run: make test
   test-db:
@@ -38,6 +38,21 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version-file: 'go.mod'
       - name: Run Tests
         run: make test-db
+  test-serverless:
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+      working-directory: ./serverless/digitalocean/packages/zest/refresh
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Run Tests
+        run: go test ./...

--- a/serverless/digitalocean/packages/zest/refresh/go.mod
+++ b/serverless/digitalocean/packages/zest/refresh/go.mod
@@ -2,9 +2,14 @@ module refresh
 
 go 1.20
 
-require github.com/json-iterator/go v1.1.12
+require (
+	github.com/json-iterator/go v1.1.12
+	github.com/stretchr/testify v1.3.0
+)
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/serverless/digitalocean/packages/zest/refresh/refresh.go
+++ b/serverless/digitalocean/packages/zest/refresh/refresh.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"os"
-	"slices"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -24,14 +23,22 @@ type Event struct {
 }
 
 func (e Event) Valid() bool {
-	options := [3]string{"reddit", "metacritic", "spotify"}
-	return slices.Contains(options[:], e.Resource)
+	for _, opt := range [3]string{
+		"reddit",
+		"metacritic",
+		"spotify",
+	} {
+		if opt == e.Resource {
+			return true
+		}
+	}
+	return false
 }
 
 func Main(ctx context.Context, event Event) {
 	logger := log.Default()
 
-	if !slices.Contains([]string{"reddit", "metacritic", "spotify"}, event.Resource) {
+	if !event.Valid() {
 		logger.Fatal("invalid event type: ", event.Resource)
 		return
 	}

--- a/serverless/digitalocean/packages/zest/refresh/refresh_test.go
+++ b/serverless/digitalocean/packages/zest/refresh/refresh_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Simple test to verify that go.mod is setup correctly and code works e2e
+func TestEvent(t *testing.T) {
+	assert := assert.New(t)
+	e := Event{
+		Resource: "spotify",
+	}
+	assert.True(e.Valid())
+
+	e.Resource = "pandora"
+	assert.False(e.Valid())
+}


### PR DESCRIPTION
## Description
had to update the domain name, and noticed that the digital ocean function couldn't deploy.

This was because of the `slices` pkg, which is included by default in recent versions of golang. But, digital ocean only allows the `1.20` golang runtime. 

So, downgrading that code to something that works for `1.20`, and adding unit tests in the CI/CD.